### PR TITLE
Fix bug in Pintos.pm

### DIFF
--- a/modules/cs162/files/shell/bin/Pintos.pm
+++ b/modules/cs162/files/shell/bin/Pintos.pm
@@ -47,7 +47,7 @@ sub set_part {
     my ($role, $source) = $opt =~ /^([a-z]+)(?:-([a-z]+))?/ or die;
 
     $role = uc $role;
-    $source = 'FILE' if $source eq '';
+    $source = 'file' if $source eq '';
 
     die "can't have two sources for \L$role\E partition"
       if exists $parts{$role};


### PR DESCRIPTION
This seems like a typo that prevents the `--kernel` and `--loader` flags from working for the `pintos` utility script. I don't know Perl, however, so it would be great if someone who knows Perl can look over this pull request before we merge it.