### PR TITLE
Add valgrind to installed packages

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -46,6 +46,7 @@ node default {
             "qemu",
             "silversearcher-ag",
             "tmux",
+            "valgrind",
             "autoconf",
             "wget",
             "python3",


### PR DESCRIPTION
Valgrind is a lovely piece of software that helps a lot with some of the earlier homeworks and the like. I think most people ended up installing it manually, but it probably wouldn’t hurt to have it come installed by default.