### PR TITLE
More Docker image improvements

### DIFF
--- a/.github/workflows/build-unstable.yml
+++ b/.github/workflows/build-unstable.yml
@@ -1,0 +1,28 @@
+name: Docker build
+
+on:
+  push:
+    branches:
+      - 'docker-unstable'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          platforms: linux/amd64
+          tags: ${{ secrets.DOCKERHUB_REPOSITORY }}:unstable
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Docker build
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'docker-dev'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          platforms: linux/amd64
+          tags: ${{ secrets.DOCKERHUB_REPOSITORY }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,5 @@ RUN echo "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/hom
 FROM ubuntu:18.04
 
 COPY --from=src . .
+
+ENTRYPOINT ["bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,19 @@ RUN apt -y update && apt -y install puppet
 COPY modules /puppet/modules
 COPY manifests /puppet/manifests
 
-
-FROM ubuntu:18.04 as puppet
-
-COPY --from=src . .
-
 RUN puppet apply /puppet/manifests/site.pp --modulepath /puppet/modules
+
+# No longer need our puppet files, save about 4.3M
+RUN rm -rf /puppet
+# No longer need puppet, save about 49.4 MB
+RUN apt -y purge --auto-remove puppet
+# In case for some reason we have orphans
+RUN apt -y autoremove --purge
+# No longer need puppet, samba, apt, etc., can savely save 3.6M
+RUN rm -rf /var/cache
+# No longer need apt, can savely save 40M
+RUN rm -rf /var/lib/apt/lists/
+
 # I am trusting that the following command depends on puppet;
 # If running puppet will not change this, then this should happen well in advance of puppet apply, for build caching
 RUN echo "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/vagrant/.bin:/home/vagrant/.cargo/bin:/home/vagrant/.fzf/bin" >> /etc/environment
@@ -21,4 +28,4 @@ RUN echo "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/hom
 
 FROM ubuntu:18.04
 
-COPY --from=puppet . .
+COPY --from=src . .


### PR DESCRIPTION
Continues #13 

- Adds CI actions to build and push image (to DockerHub)
  - To use, set GitHub Actions secrets `DOCKERHUB_USERNAME` (ex: `avimehra`), `DOCKERHUB_TOKEN` (auth token), and `DOCKERHUB_REPOSITORY` (ex: `avimehra/vagrant`)
  - Adds an action to build and push the `:unstable` tag from `docker-unstable` branch
- Reduce image size by over 100 MB
- Set entrypoint

Feel free to remove/modify any of these commits; I don't need this branch